### PR TITLE
Fix delayed job custom yamler for Trello::ApiObject

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,7 +15,7 @@ ENV['RACK_ENV'] ||= 'development'
 
 set :database_file, File.join(File.dirname(__FILE__), 'config', 'database.yml')
 
-['config', 'lib', 'models', 'mailers', 'workers'].each do |path|
+['config', 'initializers', 'lib', 'models', 'mailers', 'workers'].each do |path|
   Dir[File.dirname(__FILE__)+"/#{path}/*.rb"].each { |file| require file }
 end
 

--- a/initializers/delayed_job_psych_bugfix.rb
+++ b/initializers/delayed_job_psych_bugfix.rb
@@ -1,0 +1,18 @@
+delayed_job_version = Gem.loaded_specs['delayed_job'].version.to_s
+
+unless '4.0.0' == delayed_job_version
+  raise LoadError, "Delayed Job has been upgraded to #{delayed_job_version}, consider deleting this monkeypatch"
+end
+
+module Psych
+  module Visitors
+    class ToRuby
+      def visit_Psych_Nodes_Mapping_with_delayed_jobs_bugfix(object)
+        return revive(Psych.load_tags[object.tag].constantize, object) if Psych.load_tags[object.tag]
+
+        visit_Psych_Nodes_Mapping_without_delayed_jobs_bugfix(object)
+      end
+      alias_method_chain :visit_Psych_Nodes_Mapping, :delayed_jobs_bugfix
+    end
+  end
+end

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -1,6 +1,6 @@
 class Trello
   class ApiObject
-    yaml_as "tag:ruby.yaml.org,2002:TrelloApiObject"
+    yaml_tag "tag:ruby.yaml.org,2002:TrelloApiObject"
 
     def initialize(attrs = {})
       self.delegate_map = attrs


### PR DESCRIPTION
- There appears to be a bug in delayed job where, when you have a custom
  yaml tag for an object, as Trello::ApiObject does, it tries to call
  into psych's `revive` method with a string instead of a class, because
  `Psych.load_tags` used to be a map of classes and now is a map of
  strings
- Will try to patch upstream