### PR TITLE
Fix for trello object deserializing

### DIFF
--- a/initializers/delayed_job_psych_bugfix.rb
+++ b/initializers/delayed_job_psych_bugfix.rb
@@ -4,15 +4,13 @@ unless '4.0.6' == delayed_job_version
   raise LoadError, "Delayed Job has been upgraded to #{delayed_job_version}, consider deleting this monkeypatch"
 end
 
-module Psych
-  module Visitors
-    class ToRuby
-      def visit_Psych_Nodes_Mapping_with_delayed_jobs_bugfix(object)
-        return revive(Psych.load_tags[object.tag].constantize, object) if Psych.load_tags[object.tag]
+module FixPsych
+  def visit_Psych_Nodes_Mapping(object)
+    return revive(Psych.load_tags[object.tag].constantize, object) if Psych.load_tags[object.tag]
 
-        visit_Psych_Nodes_Mapping_without_delayed_jobs_bugfix(object)
-      end
-      alias_method_chain :visit_Psych_Nodes_Mapping, :delayed_jobs_bugfix
-    end
+    super(object)
   end
 end
+
+Psych::Visitors::ToRuby.prepend(FixPsych)
+Delayed::PsychExt::ToRuby.prepend(FixPsych)


### PR DESCRIPTION
- Because delayed job seems to have introduced another layer of
indirection to how they patch psych for deserializing jobs, this change
inserts our patch both at the delayed job level and at the psych level